### PR TITLE
chore: update git repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,19 +16,19 @@
   "private": false,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/decentraland/script.git"
+    "url": "git+https://github.com/decentraland/decentraland-rpc.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/decentraland/script/issues"
+    "url": "https://github.com/decentraland/decentraland-rpc/issues"
   },
   "bin": {
     "decentraland-compiler": "./bin/compile.js",
     "metaverse-compiler": "./bin/compile.js"
   },
-  "homepage": "https://github.com/decentraland/script#readme",
+  "homepage": "https://github.com/decentraland/decentraland-rpc#readme",
   "devDependencies": {
     "@types/express": "^4.16.0",
     "@types/glob": "^5.0.34",


### PR DESCRIPTION
**What does this do?**

It just changes the repo links in `./package.json` from https://github.com/decentraland/script to https://github.com/decentraland/decentraland-rpc.