### PR TITLE
feat: support ESM target

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,6 +121,12 @@
         "@types/mime": "*"
       }
     },
+    "@types/source-list-map": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
+      "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
+      "dev": true
+    },
     "@types/tapable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.4.tgz",
@@ -154,6 +160,25 @@
         "@types/tapable": "*",
         "@types/uglify-js": "*",
         "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "@types/webpack-sources": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-0.1.5.tgz",
+      "integrity": "sha512-zfvjpp7jiafSmrzJ2/i3LqOyTYTuJ7u1KOXlKgDlvsj9Rr0x7ZiYu5lZbXwobL7lmsRNtPXlBfmaUD8eU2Hu8w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/source-list-map": "*",
+        "source-map": "^0.6.1"
       },
       "dependencies": {
         "source-map": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/progress": "^2.0.1",
     "@types/rimraf": "^2.0.2",
     "@types/webpack": "^4.4.17",
+    "@types/webpack-sources": "^0.1.5",
     "@types/ws": "^4.0.2",
     "assert": "^1.4.1",
     "dcl-tslint-config-standard": "^1.1.0",


### PR DESCRIPTION
This branch enables the decentraland-compiler to bundle ES modules when specified.

Example build file:

```
[
  {
    "name": "Compile",
    "kind": "Webpack",
    "file": "./src/index.ts",
    "target": "esm",
    "library": "ethconnect"
  }
]
```

Where target must be `esm` for the feature to be enabled and `library` refers to the library name that will also be the variable exported by the module itself.

Logic-wise, Webpack does not support targeting ESM so the implemented workaround involves targeting `var` (the whole bundle contained in a variable) and exporting that variable using the ES module syntax.

This change allows eth-connect to be bundled and consumed inside DCL's parcels.